### PR TITLE
Fix primitive reference point for alpha sorting

### DIFF
--- a/bms_blender_plugin/exporter/parser.py
+++ b/bms_blender_plugin/exporter/parser.py
@@ -6,8 +6,12 @@ from bms_blender_plugin.common.blender_types import BlenderNodeType
 from bms_blender_plugin.common.bml_structs import Primitive, PrimitiveTopology, Vector3, Slot, D3DMatrix, Switch, \
     DofType, Dof
 from bms_blender_plugin.common.hotspot import Hotspot, MouseButton, ButtonType
-from bms_blender_plugin.common.util import get_bml_type, get_objcenter, get_switches, get_dofs, \
-    get_non_translate_dof_parent
+from bms_blender_plugin.common.util import (
+    get_bml_type,
+    get_switches,
+    get_dofs,
+    get_non_translate_dof_parent,
+)
 from bms_blender_plugin.exporter.bml_mesh import get_bml_mesh_data, get_pbr_light_data
 from bms_blender_plugin.common.coordinates import to_bms_coords
 
@@ -58,7 +62,7 @@ def parse_mesh(
     if get_bml_type(obj.parent) == BlenderNodeType.DOF and obj.parent.dof_type != DofType.TRANSLATE.name:
         reference_point = to_bms_coords((0, 0, 0))
     else:
-        reference_point = get_objcenter(obj)
+        reference_point = to_bms_coords(obj.matrix_world.translation)
 
     node = Primitive(
         index=len(nodes),
@@ -122,7 +126,7 @@ def parse_bbl_light(
     for obj_vertex in obj_vertices:
         obj_vertices_data += obj_vertex.to_data()
 
-    reference_point = get_objcenter(obj)
+    reference_point = to_bms_coords(obj.matrix_world.translation)
     node = Primitive(
         index=len(nodes),
         topology=PrimitiveTopology.TRIANGLE_LIST,

--- a/docs/Manual/MANUAL.md
+++ b/docs/Manual/MANUAL.md
@@ -43,6 +43,7 @@
   * [14.1 BMS Editor crashing / not opening](#141-bms-editor-crashing-or-not-opening)
   * [14.2 Weird Normals / Triangulation](#142-weird-normals-or-triangulation)
   * [14.3 BMS Crashing](#143-bms-crashing)
+  * [14.4 Alpha Sorting](#144-alpha-sorting)
 
 ---
 
@@ -492,3 +493,7 @@ If your model works fine in the BMS Editor and displays correctly in the *Tactic
 * Check the ``Parent.dat``. If there is already an older version of a previous model you can reuse, try that one
 
 If you can't find the reason of the BMS crash, please report it with the the relevant ```_xlog.txt```, ```_crash.txt``` and ```_crash.dmp``` from your ```<Your Falcon BMS Directory>/User/Logs```.
+
+### 14.4 Alpha Sorting
+When exporting primitives individually (using the *Do not merge* option), the exporter uses the object's origin as the reference point for alpha sorting.
+Shift the origin in Blender to adjust the draw order of transparent geometry.


### PR DESCRIPTION
## Summary
- set primitive reference point to object origin
- document alpha sorting behaviour in manual

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_686037055c8083208d061547b74d54a1