### PR TITLE
Store switch numbers on objects

### DIFF
--- a/bms_blender_plugin/exporter/export_parent_dat.py
+++ b/bms_blender_plugin/exporter/export_parent_dat.py
@@ -22,14 +22,20 @@ def get_highest_switch_and_dof_number(objs):
         if len(obj.children) > 0:
             if get_bml_type(obj) == BlenderNodeType.SWITCH:
                 try:
-                    switch = get_switches()[obj.switch_list_index]
-                    """parent.dat requires max(switch)+1 to function correctly due to a = vs <= issue in the BMS code. 
+                    if hasattr(obj, "switch_number") and hasattr(obj, "switch_branch"):
+                        switch_number = obj.switch_number
+                    else:
+                        switch = get_switches()[obj.switch_list_index]
+                        switch_number = switch.switch_number
+                    """parent.dat requires max(switch)+1 to function correctly due to a = vs <= issue in the BMS code.
                     This Should be resolved for 4.38."""
-                    required_switch_index = switch.switch_number+1
+                    required_switch_index = switch_number + 1
                     if required_switch_index > highest_switch_number:
                         highest_switch_number = required_switch_index
                 except IndexError:
-                    raise IndexError(f"Switch index {obj.switch_list_index} not found in switch.xml. Object: {obj.name}. Please update XML files and reload switch list.")
+                    raise IndexError(
+                        f"Switch index {obj.switch_list_index} not found in switch.xml. Object: {obj.name}. Please update XML files and reload switch list."
+                    )
             elif get_bml_type(obj) == BlenderNodeType.DOF:
                 try:
                     dof = get_dofs()[obj.dof_list_index]

--- a/bms_blender_plugin/exporter/parser.py
+++ b/bms_blender_plugin/exporter/parser.py
@@ -173,9 +173,14 @@ def parse_slot(obj, nodes):
 def parse_switch(obj, nodes):
     """Adds a BML Switch to the BML node list"""
     print(f"{obj.name} is a SWITCH")
-    switch = get_switches()[obj.switch_list_index]
+    switch_number = getattr(obj, "switch_number", None)
+    switch_branch = getattr(obj, "switch_branch", None)
+    if switch_number is None or switch_branch is None:
+        switch = get_switches()[obj.switch_list_index]
+        switch_number = switch.switch_number
+        switch_branch = switch.branch
     nodes.append(
-        Switch(len(nodes), switch.switch_number, switch.branch, obj.switch_default_on)
+        Switch(len(nodes), switch_number, switch_branch, obj.switch_default_on)
     )
     return ParsedNodes(vertex_data=[], vertices_length=0, vertices_size=0)
 

--- a/bms_blender_plugin/ui_tools/dof_behaviour.py
+++ b/bms_blender_plugin/ui_tools/dof_behaviour.py
@@ -120,6 +120,8 @@ def update_switch_or_dof_name(obj, context):
     name updates by the user."""
     if get_bml_type(obj) == BlenderNodeType.SWITCH:
         active_switch = get_switches()[obj.switch_list_index]
+        obj.switch_number = active_switch.switch_number
+        obj.switch_branch = active_switch.branch
         obj.name = f"Switch - {active_switch.name} ({active_switch.switch_number})"
     elif get_bml_type(obj) == BlenderNodeType.DOF:
         active_dof = get_dofs()[obj.dof_list_index]

--- a/bms_blender_plugin/ui_tools/operators/__init__.py
+++ b/bms_blender_plugin/ui_tools/operators/__init__.py
@@ -74,6 +74,16 @@ def register_blender_properties():
     bpy.types.Object.switch_default_on = bpy.props.BoolProperty(
         name="Default ON", description="The switch is ON by default", default=False
     )
+    bpy.types.Object.switch_number = bpy.props.IntProperty(
+        name="Switch Number",
+        description="Number of the selected switch",
+        default=0,
+    )
+    bpy.types.Object.switch_branch = bpy.props.IntProperty(
+        name="Switch Branch",
+        description="Branch number of the selected switch",
+        default=0,
+    )
 
     # DOFs
     bpy.types.Object.dof_list_index = bpy.props.IntProperty(

--- a/bms_blender_plugin/ui_tools/operators/create_switch.py
+++ b/bms_blender_plugin/ui_tools/operators/create_switch.py
@@ -28,6 +28,9 @@ class CreateSwitch(Operator):
             f"Switch - {switch.name} ({switch.switch_number})", None
         )
         switch_object.bml_type = str(BlenderNodeType.SWITCH)
+        switch_object.switch_number = switch.switch_number
+        switch_object.switch_branch = switch.branch
+        switch_object.switch_list_index = 0
 
         if context.active_object:
             # assumes that every object is linked to at least one collection


### PR DESCRIPTION
## Summary
- add `switch_number` and `switch_branch` properties
- keep these properties in sync when switch list index changes
- initialise switch properties in operator
- use stored values during export

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6861478baa2c8320a4697e85b820c448